### PR TITLE
Update tokrules.py

### DIFF
--- a/src/Mod/OpenSCAD/tokrules.py
+++ b/src/Mod/OpenSCAD/tokrules.py
@@ -86,7 +86,7 @@ tokens = reserved + (
 
 # Regular expression rules for simple tokens
 t_WORD    = r'[$]?[a-zA-Z_]+[0-9]*'
-t_NUMBER  = r'[-]?[0-9]*[\.]*[0-9]+([eE]-?[0-9]+)*'
+t_NUMBER  = r'[-]?[0-9]*[\.]*[0-9]+([eE][+-]?[0-9]+)*'
 t_LPAREN  = r'\('
 t_RPAREN  = r'\)'
 t_OBRACE  = r'{'


### PR DESCRIPTION
Fix OpenSCAD importer parsing error for numbers with positive exponents > 6

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
